### PR TITLE
Develop: Generalized Monte Carlo, fixed dropped samples in MPI runs

### DIFF
--- a/tests/mlmc/test_MLMCSimulator.py
+++ b/tests/mlmc/test_MLMCSimulator.py
@@ -228,7 +228,7 @@ def test_calculate_initial_variances(beta_distribution_input, spring_models):
     sim = MLMCSimulator(models=spring_models, data=beta_distribution_input)
 
     np.random.seed(1)
-    sim._initial_sample_size = 100 // sim._number_cpus
+    sim._initial_sample_size = 100 // sim._num_cpus
 
     costs, variances = sim._compute_costs_and_variances()
 
@@ -355,7 +355,7 @@ def test_monte_carlo_estimate_value(data_input, models_from_data):
     models = [models_from_data[0]]
 
     sim = MLMCSimulator(models=models, data=data_input)
-    estimate, sample_sizes, variances = sim.simulate(1., 50)
+    estimate, sample_sizes, variances = sim.simulate(.05, 50)
 
     assert np.isclose(estimate, mc_20000_output_sample_mean, atol=.25)
 
@@ -454,7 +454,7 @@ def test_fixed_cost(beta_distribution_input, spring_models, target_cost):
 
     # Multiply sample sizes times costs and take the sum; verify that this is
     # close to the target cost.
-    sim._initial_sample_size = 100 // sim._number_cpus
+    sim._initial_sample_size = 100 // sim._num_cpus
     sim._target_cost = target_cost
 
     costs, variances = sim._compute_costs_and_variances()

--- a/tests/mlmc/test_MLMCSimulator.py
+++ b/tests/mlmc/test_MLMCSimulator.py
@@ -375,6 +375,30 @@ def test_mc_output_shapes_match_mlmc(data_input, models_from_data):
     assert mc_sample_sizes.shape != mlmc_sample_sizes.shape
 
 
+@pytest.mark.parametrize('num_cpus', [1, 2, 3, 4, 7, 12])
+def test_multi_cpu_sample_sizing(data_input, models_from_data, num_cpus):
+
+    total_samples = 100
+
+    sample_sizes = np.zeros(num_cpus)
+
+    sim = MLMCSimulator(models=models_from_data, data=data_input)
+
+    for cpu_rank in range(num_cpus):
+
+        sim._num_cpus = num_cpus
+        sim._cpu_rank = cpu_rank
+
+        sample_sizes[cpu_rank] = sim._determine_num_cpu_samples(total_samples)
+
+    # Test that all samples will be utilized.
+    assert np.sum(sample_sizes) == total_samples
+
+    # Test that there is never more than a difference of one sample
+    # between processes.
+    assert np.max(sample_sizes) - np.min(sample_sizes) <= 1
+
+
 def test_hard_coded_test_2_level(data_input, models_from_data):
 
     # Get simulation results.


### PR DESCRIPTION
Single model runs will now run the general MLMC code rather than specialized Monte Carlo code, which produces the same results. 

When running on multiple processors, samples that could not be divided evenly among processors will now be distributed such that the maximum difference in sample sizes among processes is 1.